### PR TITLE
Fix unmarshaling error when TotalSizeLo < 0

### DIFF
--- a/nzbget.go
+++ b/nzbget.go
@@ -349,7 +349,7 @@ type ServerVolume struct {
 func (v *ServerVolume) UnmarshalJSON(b []byte) error {
 	type temp struct {
 		ServerID    int    `json:"ServerID"`
-		TotalSizeLo uint32 `json:"TotalSizeLo"`
+		TotalSizeLo int32  `json:"TotalSizeLo"`
 		TotalSizeHi uint32 `json:"TotalSizeHi"`
 	}
 
@@ -360,6 +360,12 @@ func (v *ServerVolume) UnmarshalJSON(b []byte) error {
 	}
 
 	v.ID = values.ServerID
-	v.TotalBytes = joinInt64(values.TotalSizeLo, values.TotalSizeHi)
+
+	// For some reason *Lo values might be negative on the serialized JSON received from NZBGet causing an error:
+	// `json: cannot unmarshal number -1 into Go struct field temp.TotalSizeLo of type uint32`
+	// See: https://forum.nzbget.net/viewtopic.php?t=3711
+	// For this reason, we unmarshal them as signed then use the unsigned value
+	v.TotalBytes = joinInt64(uint32(values.TotalSizeLo), values.TotalSizeHi)
+
 	return nil
 }

--- a/nzbget.go
+++ b/nzbget.go
@@ -64,19 +64,19 @@ func (s *Status) UnmarshalJSON(b []byte) error {
 
 	type temp struct {
 		ArticleCacheHi   uint32 `json:"ArticleCacheHi"`
-		ArticleCacheLo   uint32 `json:"ArticleCacheLo"`
+		ArticleCacheLo   int32  `json:"ArticleCacheLo"`
 		DaySizeHi        uint32 `json:"DaySizeHi"`
-		DaySizeLo        uint32 `json:"DaySizeLo"`
+		DaySizeLo        int32  `json:"DaySizeLo"`
 		DownloadedSizeHi uint32 `json:"DownloadedSizeHi"`
-		DownloadedSizeLo uint32 `json:"DownloadedSizeLo"`
+		DownloadedSizeLo int32  `json:"DownloadedSizeLo"`
 		ForcedSizeHi     uint32 `json:"ForcedSizeHi"`
-		ForcedSizeLo     uint32 `json:"ForcedSizeLo"`
+		ForcedSizeLo     int32  `json:"ForcedSizeLo"`
 		FreeDiskSpaceHi  uint32 `json:"FreeDiskSpaceHi"`
-		FreeDiskSpaceLo  uint32 `json:"FreeDiskSpaceLo"`
+		FreeDiskSpaceLo  int32  `json:"FreeDiskSpaceLo"`
 		MonthSizeHi      uint32 `json:"MonthSizeHi"`
-		MonthSizeLo      uint32 `json:"MonthSizeLo"`
+		MonthSizeLo      int32  `json:"MonthSizeLo"`
 		RemainingSizeHi  uint32 `json:"RemainingSizeHi"`
-		RemainingSizeLo  uint32 `json:"RemainingSizeLo"`
+		RemainingSizeLo  int32  `json:"RemainingSizeLo"`
 
 		ServerTime int64 `json:"ServerTime"`
 		ResumeTime int64 `json:"ResumeTime"`
@@ -342,30 +342,26 @@ func reflectInto(v reflect.Value, str string) {
 }
 
 type ServerVolume struct {
-	ID         int   `json:"-"`
-	TotalBytes int64 `json:"-"`
+	ID             int   `json:"-"`
+	TotalBytes     int64 `json:"-"`
+	BytesPerSecond int64 `json:"-"`
 }
 
 func (v *ServerVolume) UnmarshalJSON(b []byte) error {
-	type temp struct {
+	values := struct {
 		ServerID    int    `json:"ServerID"`
 		TotalSizeLo int32  `json:"TotalSizeLo"`
 		TotalSizeHi uint32 `json:"TotalSizeHi"`
-	}
 
-	values := temp{}
+	}{}
+
 	err := json.Unmarshal(b, &values)
 	if err != nil {
 		return err
 	}
 
 	v.ID = values.ServerID
-
-	// For some reason *Lo values might be negative on the serialized JSON received from NZBGet causing an error:
-	// `json: cannot unmarshal number -1 into Go struct field temp.TotalSizeLo of type uint32`
-	// See: https://forum.nzbget.net/viewtopic.php?t=3711
-	// For this reason, we unmarshal them as signed then use the unsigned value
-	v.TotalBytes = joinInt64(uint32(values.TotalSizeLo), values.TotalSizeHi)
+	v.TotalBytes = joinInt64(values.TotalSizeLo, values.TotalSizeHi)
 
 	return nil
 }

--- a/nzbget_test.go
+++ b/nzbget_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestServerVolumeUnmarshal(t *testing.T) {
+
+	testCase := []byte(`
+[
+	{
+		"ServerID": 0,
+		"DataTime": 1589637733,
+		"FirstDay": 17894,
+		"TotalSizeLo": 330321954,
+		"TotalSizeHi": 762,
+		"TotalSizeMB": 3121467,
+		"CustomSizeLo": 330321954,
+		"CustomSizeHi": 762,
+		"CustomSizeMB": 3121467,
+		"CustomTime": 1546097163,
+		"SecSlot": 13,
+		"MinSlot": 2,
+		"HourSlot": 16,
+		"DaySlot": 504,
+		"BytesPerSeconds": [
+		{
+			"SizeLo": 0,
+			"SizeHi": 0,
+			"SizeMB": 0
+		}
+		]
+	},
+	{
+		"ServerID": 2,
+		"DataTime": 1589637733,
+		"FirstDay": 17894,
+		"TotalSizeLo": -1059258586,
+		"TotalSizeHi": 3,
+		"TotalSizeMB": 15373,
+		"CustomSizeLo": -1059258586,
+		"CustomSizeHi": 3,
+		"CustomSizeMB": 15373,
+		"CustomTime": 1546097163,
+		"SecSlot": 13,
+		"MinSlot": 2,
+		"HourSlot": 16,
+		"DaySlot": 504,
+		"BytesPerSeconds": [
+		{
+			"SizeLo": 0,
+			"SizeHi": 0,
+			"SizeMB": 0
+		},
+		{
+			"SizeLo": 134212,
+			"SizeHi": 20,
+			"SizeMB": 81920
+		}
+		]
+	}
+]
+`)
+
+	out := []ServerVolume{}
+	err := json.Unmarshal(testCase, &out)
+
+	if err != nil {
+		t.Errorf("Failed to unmarshal. Error: %s", err)
+	}
+
+	if !reflect.DeepEqual(out[0], ServerVolume{
+		ID:         0,
+		TotalBytes: 3273095401506, // 3273095401506/1024/1024 == 3121467 MB (TotalSizeMB)
+	}) {
+		t.Errorf("Unexpected ServerVolume[0]: %#v", out[0])
+	}
+
+	if !reflect.DeepEqual(out[1], ServerVolume{
+		ID:         2,
+		TotalBytes: 16120610598, // 16120610598/1024/1024 == 15373 MB (TotalSizeMB)
+	}) {
+		t.Errorf("Unexpected ServerVolume[1]: %#v", out[1])
+	}
+}

--- a/util.go
+++ b/util.go
@@ -1,6 +1,8 @@
 package main
 
-import "strings"
+import (
+	"strings"
+)
 
 func floatOf(b bool) float64 {
 	if b {
@@ -22,6 +24,12 @@ func getBool(s string) bool {
 	return false
 }
 
-func joinInt64(lo, hi uint32) int64 {
-	return (int64(hi) << 32) + int64(lo)
+func joinInt64(lo int32, hi uint32) int64 {
+	// For some reason *Lo values might be negative on the serialized JSON received from NZBGet causing an error:
+	// `json: cannot unmarshal number -1 into Go struct field temp.TotalSizeLo of type uint32`
+	// See: https://forum.nzbget.net/viewtopic.php?t=3711
+	// For this reason, we unmarshal them as signed then use the unsigned value
+	ulo := uint32(lo)
+
+	return (int64(hi) << 32) + int64(ulo)
 }


### PR DESCRIPTION
For some reason `TotalSizeLo` values might be negative, causing an error: `json: cannot unmarshal number -1 into Go struct field temp.TotalSizeLo of type uint32`

See: https://forum.nzbget.net/viewtopic.php?t=3711