### PR TITLE
Added total article Success/Fail (All time)

### DIFF
--- a/collect.go
+++ b/collect.go
@@ -40,6 +40,7 @@ type NZBGetCollector struct {
 	newsServerActive         *prom.Desc
 	newsServerBytes          *prom.Desc
 	newsServerArticleSuccess *prom.Desc
+	newsServerArticleFailed *prom.Desc
 
 	historyCategoryCount       *prom.Desc
 	historyFileSizeBytes       *prom.Desc
@@ -182,6 +183,11 @@ func NewNZBGetCollector(config *ExporterConfig) *NZBGetCollector {
 		newsServerArticleSuccess: prom.NewDesc(
 			prom.BuildFQName(ns, "news_server", "total_article_success"),
 			"Total successful articles from this news server",
+			[]string{"id", "server"}, nil,
+		),
+		newsServerArticleFailed: prom.NewDesc(
+			prom.BuildFQName(ns, "news_server", "total_article_failed"),
+			"Total failed articles from this news server",
 			[]string{"id", "server"}, nil,
 		),
 		historyCategoryCount: prom.NewDesc(
@@ -376,9 +382,8 @@ func (c *NZBGetCollector) Collect(metrics chan<- prom.Metric) {
 
 			metrics <- prom.MustNewConstMetric(c.newsServerBytes, prom.GaugeValue, bytes, id, name)
 
-			// NGA tidy up start
 			metrics <- prom.MustNewConstMetric(c.newsServerArticleSuccess, prom.CounterValue, float64(volume[idx].TotalArticleSuccess), id, name)
-			// NGA tidy up end
+			metrics <- prom.MustNewConstMetric(c.newsServerArticleFailed, prom.CounterValue, float64(volume[idx].TotalArticleFailed), id, name)
 
 		}
 	}()

--- a/collect.go
+++ b/collect.go
@@ -37,8 +37,9 @@ type NZBGetCollector struct {
 	threadCount     *prom.Desc
 	urlCount        *prom.Desc
 
-	newsServerActive *prom.Desc
-	newsServerBytes  *prom.Desc
+	newsServerActive         *prom.Desc
+	newsServerBytes          *prom.Desc
+	newsServerArticleSuccess *prom.Desc
 
 	historyCategoryCount       *prom.Desc
 	historyFileSizeBytes       *prom.Desc
@@ -178,7 +179,11 @@ func NewNZBGetCollector(config *ExporterConfig) *NZBGetCollector {
 			"Total bytes downloaded from this news server",
 			[]string{"id", "server"}, nil,
 		),
-
+		newsServerArticleSuccess: prom.NewDesc(
+			prom.BuildFQName(ns, "news_server", "total_article_success"),
+			"Total successful articles from this news server",
+			[]string{"id", "server"}, nil,
+		),
 		historyCategoryCount: prom.NewDesc(
 			prom.BuildFQName(ns, "history_category", "count"),
 			"Number of history items in each category",
@@ -370,6 +375,11 @@ func (c *NZBGetCollector) Collect(metrics chan<- prom.Metric) {
 			bytes := float64(volume[idx].TotalBytes)
 
 			metrics <- prom.MustNewConstMetric(c.newsServerBytes, prom.GaugeValue, bytes, id, name)
+
+			// NGA tidy up start
+			metrics <- prom.MustNewConstMetric(c.newsServerArticleSuccess, prom.CounterValue, float64(volume[idx].TotalArticleSuccess), id, name)
+			// NGA tidy up end
+
 		}
 	}()
 

--- a/nzbget.go
+++ b/nzbget.go
@@ -342,15 +342,23 @@ func reflectInto(v reflect.Value, str string) {
 }
 
 type ServerVolume struct {
-	ID         int   `json:"-"`
-	TotalBytes int64 `json:"-"`
+	ID                  int   `json:"-"`
+	TotalBytes          int64 `json:"-"`
+	TotalArticleSuccess int   `json:"-"`
 }
 
 func (v *ServerVolume) UnmarshalJSON(b []byte) error {
+
+	type ArticlePerDay struct {
+		Success int `json:"Success"`
+		Failed  int `json:"Failed"`
+	}
+
 	type temp struct {
-		ServerID    int    `json:"ServerID"`
-		TotalSizeLo uint32 `json:"TotalSizeLo"`
-		TotalSizeHi uint32 `json:"TotalSizeHi"`
+		ServerID        int             `json:"ServerID"`
+		TotalSizeLo     uint32          `json:"TotalSizeLo"`
+		TotalSizeHi     uint32          `json:"TotalSizeHi"`
+		ArticlesPerDays []ArticlePerDay `json:"ArticlesPerDays"`
 	}
 
 	values := temp{}
@@ -361,5 +369,16 @@ func (v *ServerVolume) UnmarshalJSON(b []byte) error {
 
 	v.ID = values.ServerID
 	v.TotalBytes = joinInt64(values.TotalSizeLo, values.TotalSizeHi)
+
+	// NGA tidy up start
+	var totalSuccess, totalFailed int
+	for _, day := range values.ArticlesPerDays {
+		totalSuccess += day.Success
+		totalFailed += day.Failed
+	}
+
+	v.TotalArticleSuccess = totalSuccess
+	// NGA tidy up end
+
 	return nil
 }

--- a/nzbget.go
+++ b/nzbget.go
@@ -345,6 +345,7 @@ type ServerVolume struct {
 	ID                  int   `json:"-"`
 	TotalBytes          int64 `json:"-"`
 	TotalArticleSuccess int   `json:"-"`
+	TotalArticleFailed int   `json:"-"`
 }
 
 func (v *ServerVolume) UnmarshalJSON(b []byte) error {
@@ -370,7 +371,6 @@ func (v *ServerVolume) UnmarshalJSON(b []byte) error {
 	v.ID = values.ServerID
 	v.TotalBytes = joinInt64(values.TotalSizeLo, values.TotalSizeHi)
 
-	// NGA tidy up start
 	var totalSuccess, totalFailed int
 	for _, day := range values.ArticlesPerDays {
 		totalSuccess += day.Success
@@ -378,7 +378,7 @@ func (v *ServerVolume) UnmarshalJSON(b []byte) error {
 	}
 
 	v.TotalArticleSuccess = totalSuccess
-	// NGA tidy up end
+	v.TotalArticleFailed = totalFailed
 
 	return nil
 }


### PR DESCRIPTION
The current Article Success and Fail only counts what is in history, which I didn't find very useful as it fluctuated a lot and wouldn't display a graph correctly in Grafana.

This code counts 'all time' Success and Fail per server, as a 'Count' metric.
This is ideal for plotting on graphs.



As an aside, apologies if the formatting of code or whatnot is not up to scratch, this is my first time writing Go and my first time writing a PR for another person's repo.

Hope this is useful1